### PR TITLE
Add support for transpiling import statements

### DIFF
--- a/test/fixtures/import.no.modules.expected.js
+++ b/test/fixtures/import.no.modules.expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 var styles = {
   "simple": "_simple_jvai8_1"
 }; // @related-file ./simple.css

--- a/test/fixtures/import.no.name.js
+++ b/test/fixtures/import.no.name.js
@@ -1,0 +1,1 @@
+import 'simple.css';

--- a/test/fixtures/import.nocss.js
+++ b/test/fixtures/import.nocss.js
@@ -1,0 +1,1 @@
+import notStyles from './foo.cs';

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,16 +6,24 @@ import * as babel from 'babel-core';
 
 const fixtures = path.join(__dirname, 'fixtures');
 
-export const transform = (filename: string): Promise<string> => {
+export const babelNoModules = {
+  presets: [ ['env', { modules: false, targets: { node: 'current' } }] ],
+};
+
+export const transform = (filename: string,
+                          babelOptionOverrides: ?{ [string]: mixed }
+                          ): Promise<string> => {
   const file = path.join(fixtures, filename);
-  const options = {
+
+  const options = Object.assign({
+    babelrc: false,
     presets: [ ['env', { targets: { node: 'current' } }] ],
     plugins: [
       ['../../src/plugin.js', {
         config: path.join(fixtures, 'postcss.config.js'),
       }],
     ],
-  };
+  }, babelOptionOverrides);
 
   return new Promise((resolve: (any) => void, reject: (Error) => void) => {
     babel.transformFile(file, options, (err: ?Error, result: any) => {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -11,6 +11,7 @@ import {
 import {
   read,
   transform,
+  babelNoModules,
 } from './helpers';
 
 import {
@@ -127,6 +128,48 @@ describe('babel-plugin-transform-postcss', () => {
     it('does not launch a client', () => {
       expect(childProcess.execFileSync).to.not.have.been.called;
     });
+  });
+
+  describe('when transforming import.no.name.js', () => {
+    beforeEach(() => transform('import.no.name.js', babelNoModules));
+
+    it('does not launch the server', () => {
+      expect(childProcess.spawn).to.not.have.been.called;
+    });
+
+    it('does not launch a client', () => {
+      expect(childProcess.execFileSync).to.not.have.been.called;
+    });
+  });
+
+  describe('when transforming import.nocss.js', () => {
+    beforeEach(() => transform('import.nocss.js', babelNoModules));
+
+    it('does not launch the server', () => {
+      expect(childProcess.spawn).to.not.have.been.called;
+    });
+
+    it('does not launch a client', () => {
+      expect(childProcess.execFileSync).to.not.have.been.called;
+    });
+  });
+
+  describe('when transforming import.js without modules', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await transform('import.js', babelNoModules);
+    });
+
+    it('launches the server', testServerLaunched);
+    it('launches a client', () => testClientLaunched('simple.css'));
+    it('compiles correctly', async () => {
+      expect(result).to.eql(
+          (await read('import.no.modules.expected.js')).trim()
+      );
+    });
+
+    shouldBehaveLikeSeverIsRunning();
   });
 
   describe('when the server has been started started', () => {


### PR DESCRIPTION
With growing support for `module` builds of components (from [rollup](https://github.com/rollup/rollup/wiki/pkg.module) and [webpack](https://webpack.js.org/configuration/resolve/#resolve-mainfields)), there's a need to transform postcss without transforming `import` statements to `require` ones. 

This adds support for the `{ modules: false }` babel-config option, which skips transforming `import` statements to `require`'s

Fixes #27 