### PR TITLE
Sets target Node version to LTS in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": "current"
+        "node": "6.11.1"
       }
     }]
   ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - '7.4'
+  - '8'
+  - '6'
+  - '4'
 after_script:
   - npm install coveralls@2 && cat ./coverage/lcov.info | coveralls
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'
 after_script:
   - npm install coveralls@2 && cat ./coverage/lcov.info | coveralls
 sudo: false

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "homepage": "https://github.com/wbyoung/babel-plugin-transform-postcss",
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-core": "^6.18.0",
     "babel-eslint": "^7.1.1",
     "babel-plugin-istanbul": "^4.1.1",
     "babel-plugin-transform-flow-strip-types": "^6.21.0",


### PR DESCRIPTION
This plugin is incompatible for any versions of Node.js before 7 (See #33). This change configures Babel to compile the code against the LTS version of Node.js, which is currently 6.11.1.