### PR TITLE
Add `retainImport` option 

### DIFF
--- a/test/fixtures/import.retain.expected.js
+++ b/test/fixtures/import.retain.expected.js
@@ -1,0 +1,6 @@
+import "./simple.css";
+var styles = {
+  "simple": "_simple_jvai8_1"
+}; // @related-file ./simple.css
+
+console.log(styles);

--- a/test/fixtures/require.retain.expected.js
+++ b/test/fixtures/require.retain.expected.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('./simple.css');
+
+var styles = {
+  'simple': '_simple_jvai8_1'
+}; // @related-file ./simple.css

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -13,6 +13,7 @@ export const babelNoModules = {
 export const transform = (
   filename: string,
   babelOptionOverrides: ?{ [string]: mixed },
+  pluginOptionOverrides: ?{ [string]: mixed }
 ): Promise<string> => {
   const file = path.join(fixtures, filename);
 
@@ -20,9 +21,9 @@ export const transform = (
     babelrc: false,
     presets: [ ['env', { targets: { node: 'current' } }] ],
     plugins: [
-      ['../../src/plugin.js', {
+      ['../../src/plugin.js', Object.assign({
         config: 'fixtures/postcss.config.js',
-      }],
+      }, pluginOptionOverrides)],
     ],
   }, babelOptionOverrides);
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -118,6 +118,38 @@ describe('babel-plugin-transform-postcss', () => {
     shouldBehaveLikeSeverIsRunning();
   });
 
+  describe('when transforming import.js with `retainImport: true`', () => {
+    let result;
+
+    beforeEach(async() => {
+      result = await transform('import.js', babelNoModules, { retainImport: true });
+    });
+
+    it('launches the server', testServerLaunched);
+    it('launches a client', () => testClientLaunched('simple.css'));
+    it('compiles correctly', async() => {
+      expect(result).to.eql((await read('import.retain.expected.js')).trim());
+    });
+
+    shouldBehaveLikeSeverIsRunning();
+  });
+
+  describe('when transforming require.js with `retainImport: true`', () => {
+    let result;
+
+    beforeEach(async() => {
+      result = await transform('require.js', {}, { retainImport: true });
+    });
+
+    it('launches the server', testServerLaunched);
+    it('launches a client', () => testClientLaunched('simple.css'));
+    it('compiles correctly', async() => {
+      expect(result).to.eql((await read('require.retain.expected.js')).trim());
+    });
+
+    shouldBehaveLikeSeverIsRunning();
+  });
+
   describe('when transforming nocss.js', () => {
     beforeEach(() => transform('nocss.js'));
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -122,7 +122,9 @@ describe('babel-plugin-transform-postcss', () => {
     let result;
 
     beforeEach(async() => {
-      result = await transform('import.js', babelNoModules, { retainImport: true });
+      result = await transform('import.js', babelNoModules, {
+        retainImport: true,
+      });
     });
 
     it('launches the server', testServerLaunched);


### PR DESCRIPTION
We are working on a component library which has its CSS pre-compiled using css-modules. I don't want to bundle all the css up into a single file, since I want consumers to only need to consume the CSS of the individual components they import. Therefore I want to compute the CSS modules map, but also leave an empty require in there so webpack can pick up the individual CSS files at compile time.

To solve this, I've added the `retainImport` option. When enabled, it will turn this:

```js
import styles from "./simple.css";

console.log(styles);
```

into this:

```js
import "./simple.css";
var styles = {
  "simple": "_simple_jvai8_1"
}; // @related-file ./simple.css

console.log(styles);
```

instead of this:

```js
var styles = {
  "simple": "_simple_jvai8_1"
}; // @related-file ./simple.css

console.log(styles);
```

There is one change in here I had to make, which was to only process CallExpressions if they are part of a variable declaration, otherwise I would end up in an infinite loop. Happy to look into alternatives if need be.