### PR TITLE
Exit process cleanly on SIGINT, SIGTERM, and SIGUSR2 signals

### DIFF
--- a/src/postcss-server.js
+++ b/src/postcss-server.js
@@ -121,15 +121,21 @@ const main = async function main(
         fs.unlinkSync(socketPath); // eslint-disable-line no-sync
       };
 
+      const termHandler = () => {
+        process.exit(0);
+      };
+
       server.on('close', () => {
         process.removeListener('exit', handler);
-        process.removeListener('SIGINT', handler);
-        process.removeListener('SIGTERM', handler);
+        process.removeListener('SIGINT', termHandler);
+        process.removeListener('SIGTERM', termHandler);
+        process.removeListener('SIGUSR2', termHandler);
       });
 
       process.on('exit', handler);
-      process.on('SIGINT', handler);
-      process.on('SIGTERM', handler);
+      process.on('SIGINT', termHandler);
+      process.on('SIGTERM', termHandler);
+      process.on('SIGUSR2', termHandler);
 
       resolve();
     });


### PR DESCRIPTION
Hi!

We are using this plugin for SSR workflow to take advantage of cssnext functionality.  In our development workflow we run `babel-node` through `nodemon`.  When `nodemon` restarts, it uses the `SIGUSR2` signal to cause restarts in child processes.  This plugin restarts and reports that it cannot create a new server because the existing one is already running and exists.  (It seems to be because the socket didn't get cleaned up.)  Also, when we exit `nodemon`, we have to interrupt twice to get the `postcss-server` process to end.

This PR represents the tweaks I came up with to use this plugin for our workflow.  If it works for other work flows, it would be great if it could be merged!

The basic changes are to cause the `postcss-server` to exit on any of the handled signals and delegate the `exit` handler to clean up the server socket (since it's called in all cases).

Thanks!