### PR TITLE
#50 - cleanly exit postcss-server when signaled by client process

### DIFF
--- a/src/postcss-server.js
+++ b/src/postcss-server.js
@@ -119,6 +119,7 @@ const main = async function main(
     server.on('listening', () => {
       const handler = () => {
         fs.unlinkSync(socketPath); // eslint-disable-line no-sync
+		server.close();
       };
 
       server.on('close', () => {

--- a/src/postcss-server.js
+++ b/src/postcss-server.js
@@ -119,7 +119,7 @@ const main = async function main(
     server.on('listening', () => {
       const handler = () => {
         fs.unlinkSync(socketPath); // eslint-disable-line no-sync
-		server.close();
+        server.close();
       };
 
       server.on('close', () => {


### PR DESCRIPTION
SIGTERM handler prevented process from ending - it has to stop the server explicitly in order for the rest of the cleanup logic to work as designed.