### PR TITLE
Allow version 7 of postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "string-hash": "^1.1.1"
   },
   "peerDependencies": {
-    "postcss": "^6.0.6"
+    "postcss": "^6.0.6 || ^7.0.0"
   },
   "dependencies": {
     "debug": "^3.0.0",


### PR DESCRIPTION
The plugin works great using postcss version 7.
To remove a warning when using it with latest version of postcss, I am adding it as an allowed peer dependency.

See [changelog](https://github.com/postcss/postcss/blob/master/CHANGELOG.md) for postcss

Thanks for reviewing!